### PR TITLE
Fix JSON serialization error

### DIFF
--- a/restful/common.py
+++ b/restful/common.py
@@ -27,7 +27,7 @@ def invalid_response(typ, message=None, status=400):
         content_type='application/json; charset=utf-8',
         response=json.dumps({
             'type': typ,
-            'message': message if message else 'wrong arguments (missing validation)',
+            'message': str(message) if message else 'wrong arguments (missing validation)',
         }),
     )
 


### PR DESCRIPTION
Some error messages raise a TypeError since they are not JSON serializable.  This in turn causes the server to return a generic Internal Server Message instead.  This fix casts the error message to a string first so it can be serialized.