### PR TITLE
Use default DB when specified

### DIFF
--- a/restful/controllers/main.py
+++ b/restful/controllers/main.py
@@ -50,7 +50,7 @@ class APIController(http.Controller):
     def get(self, model=None, id=None, **payload):
         try:
             ioc_name = model
-            model = request.env[self._model].search([("model", "=", model)], limit=1)
+            model = request.env[self._model].sudo().search([("model", "=", model)], limit=1)
             if model:
                 domain, fields, offset, limit, order = extract_arguments(**payload)
                 data = request.env[model.model].search_read(
@@ -106,7 +106,7 @@ class APIController(http.Controller):
         """
         payload = request.httprequest.data.decode()
         payload = json.loads(payload)
-        model = request.env[self._model].search([("model", "=", model)], limit=1)
+        model = request.env[self._model].sudo().search([("model", "=", model)], limit=1)
         values = {}
         if model:
             try:

--- a/restful/controllers/token.py
+++ b/restful/controllers/token.py
@@ -104,7 +104,6 @@ class AccessToken(http.Controller):
                     "access_token": access_token,
                     "company_name": request.env.user.company_name,
                     # "currency": request.env.user.currency_id.name,
-                    "company_name": request.env.user.company_name,
                     "country": request.env.user.country_id.name,
                     "contact_address": request.env.user.contact_address,
                     # "customer_rank": request.env.user.customer_rank,

--- a/restful/controllers/token.py
+++ b/restful/controllers/token.py
@@ -48,7 +48,7 @@ class AccessToken(http.Controller):
         params = ["db", "login", "password"]
         params = {key: post.get(key) for key in params if post.get(key)}
         db, username, password = (
-            params.get("db"),
+            params.get("db", request.session.db),
             post.get("login"),
             post.get("password"),
         )
@@ -56,7 +56,7 @@ class AccessToken(http.Controller):
         if not _credentials_includes_in_body:
             # The request post body is empty the credetials maybe passed via the headers.
             headers = request.httprequest.headers
-            db = headers.get("db")
+            db = headers.get("db", request.session.db)
             username = headers.get("login")
             password = headers.get("password")
             _credentials_includes_in_headers = all([db, username, password])


### PR DESCRIPTION
The external software need the credential, but not the db name from production when default is specified.